### PR TITLE
Fix canvas cli remote and workspace errors

### DIFF
--- a/src/commands/workspace.js
+++ b/src/commands/workspace.js
@@ -35,7 +35,7 @@ export class WorkspaceCommand extends BaseCommand {
             const secondArg = parsed.args[1];
 
             // Check if first arg is a known action
-            const knownActions = ['list', 'show', 'create', 'update', 'delete', 'start', 'stop', 'documents', 'document', 'tabs', 'notes', 'tree', 'help'];
+            const knownActions = ['list', 'show', 'create', 'update', 'delete', 'start', 'stop', 'open', 'close', 'status', 'documents', 'document', 'tabs', 'notes', 'tree', 'current', 'help'];
 
             if (knownActions.includes(firstArg)) {
                 // Route to appropriate action
@@ -572,6 +572,9 @@ export class WorkspaceCommand extends BaseCommand {
         console.log('  delete <address>               Delete workspace');
         console.log('  start <address>                Start workspace');
         console.log('  stop <address>                 Stop workspace');
+        console.log('  open <address>                 Open workspace');
+        console.log('  close <address>                Close workspace');
+        console.log('  status <address>               Show workspace status');
         console.log('  documents <address>            List documents in workspace');
         console.log('  tabs <address>                 List tabs in workspace');
         console.log('  notes <address>                List notes in workspace');

--- a/src/utils/api-client.js
+++ b/src/utils/api-client.js
@@ -37,9 +37,15 @@ class BaseCanvasApiClient {
                 config.headers.Authorization = `Bearer ${this.token}`;
             }
 
-            // Set content-type for POST/PUT/PATCH requests (whether they have data or not)
+            // Set content-type for POST/PUT/PATCH requests only when there's data
             if (config.method === 'post' || config.method === 'put' || config.method === 'patch') {
-                config.headers['Content-Type'] = 'application/json';
+                if (config.data !== undefined && config.data !== null) {
+                    config.headers['Content-Type'] = 'application/json';
+                } else {
+                    // For requests without data, send an empty JSON object to avoid server errors
+                    config.data = {};
+                    config.headers['Content-Type'] = 'application/json';
+                }
             }
 
             debug('Request:', config.method?.toUpperCase(), config.url);
@@ -549,6 +555,21 @@ export class CanvasApiClient {
     async getWorkspaceTree(addressOrId) {
         const { apiClient, resourceId } = await this.resolveResource(addressOrId);
         return await apiClient.getWorkspaceTree(resourceId);
+    }
+
+    async getWorkspaceStatus(addressOrId) {
+        const { apiClient, resourceId } = await this.resolveResource(addressOrId);
+        return await apiClient.getWorkspaceStatus(resourceId);
+    }
+
+    async openWorkspace(addressOrId) {
+        const { apiClient, resourceId } = await this.resolveResource(addressOrId);
+        return await apiClient.openWorkspace(resourceId);
+    }
+
+    async closeWorkspace(addressOrId) {
+        const { apiClient, resourceId } = await this.resolveResource(addressOrId);
+        return await apiClient.closeWorkspace(resourceId);
     }
 
     /**


### PR DESCRIPTION
Fix `canvas ws` command errors and enhance `canvas remote add` with automatic login and sync.

The `canvas ws start` command failed because the API client was sending an empty body for POST requests with `application/json` content type, leading to a 400 error. This PR ensures an empty JSON object `{}` is sent instead. Additionally, missing workspace API client methods (`getWorkspaceStatus`, `openWorkspace`, `closeWorkspace`) and CLI command routing were addressed. The `remote add` command now automatically attempts login (with `--token` support) and syncs remote data after setup.

---

[Open in Web](https://cursor.com/agents?id=bc-20da0bda-16b8-4d66-bc33-0dc646b053eb) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-20da0bda-16b8-4d66-bc33-0dc646b053eb) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)