### PR TITLE
Update cli session with current context

### DIFF
--- a/src/commands/alias.js
+++ b/src/commands/alias.js
@@ -55,7 +55,7 @@ export class AliasCommand extends BaseCommand {
                 return 0;
             }
 
-            this.output(Object.entries(aliases).map(([alias, config]) => ({
+            await this.output(Object.entries(aliases).map(([alias, config]) => ({
                 alias,
                 address: config.address,
                 createdAt: new Date(config.createdAt).toLocaleString(),

--- a/src/commands/auth.js
+++ b/src/commands/auth.js
@@ -109,7 +109,7 @@ export class AuthCommand extends BaseCommand {
             // Handle ResponseObject format
             const tokens = response.payload || response.data || response;
 
-            this.output(tokens, 'auth');
+            await this.output(tokens, 'auth');
             return 0;
         } catch (error) {
             throw new Error(`Failed to list tokens: ${error.message}`);

--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -110,13 +110,27 @@ export class BaseCommand {
      * @param {string} type - Formatter type
      * @param {string} schema - Schema type for documents
      */
-    output(data, type = 'generic', schema = null) {
+    async output(data, type = 'generic', schema = null) {
         const formatter = createFormatter(type, {
             raw: this.options?.raw || false,
             format: this.options?.format || 'table'
         });
 
-        console.log(formatter.format(data, schema));
+        // Get session data for formatters that need it
+        let session = null;
+        if (['remote', 'workspace', 'context'].includes(type)) {
+            try {
+                session = await this.apiClient.remoteStore.getSession();
+            } catch (error) {
+                this.debug('Failed to get session for formatter:', error.message);
+            }
+        }
+
+        if (type === 'document' && schema) {
+            console.log(formatter.format(data, session, schema));
+        } else {
+            console.log(formatter.format(data, session));
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Mark selected remote, workspace, and context items in CLI tables by updating `cli-session.json` with current session details.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Commands now update the session with bound context and default workspace information. The `BaseCommand.output` method fetches this session data and passes it to the respective formatters, which then display a checkmark for the currently selected item.

---

[Open in Web](https://cursor.com/agents?id=bc-26e74080-2471-4e23-94df-af5d087512ed) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-26e74080-2471-4e23-94df-af5d087512ed) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)