### PR TITLE
Debounce prompt context url updates

### DIFF
--- a/scripts/update-prompt.sh
+++ b/scripts/update-prompt.sh
@@ -13,11 +13,16 @@
 # PERFORMANCE OPTIMIZATIONS:
 # - Aggressive curl timeouts (0.5s max, 0.3s connect) for maximum speed
 # - Session/remotes data caching to reduce file I/O operations
+# - Context URL caching with configurable timeout to avoid excessive server requests
 # - Fast-fail on connection issues to avoid blocking the prompt
 # - Atomic session updates with proper cleanup on failures
 # - Automatic unbinding when API calls fail to prevent repeated failures
 
 ## Settings
+
+# Timeout configuration (in seconds) - only update context URL if cli-session was modified more than this many seconds ago
+# This prevents excessive server requests on every prompt command
+CANVAS_CONTEXT_UPDATE_TIMEOUT=30
 
 # Session file
 CANVAS_SESSION="$HOME/.canvas/config/cli-session.json"
@@ -59,6 +64,10 @@ fi
 # Cache session data to avoid multiple file reads
 _SESSION_DATA=""
 _REMOTES_DATA=""
+
+# Cache for context URL and last update timestamp
+_CACHED_CONTEXT_URL=""
+_LAST_CONTEXT_UPDATE=""
 
 get_session_data() {
     if [ -z "$_SESSION_DATA" ]; then
@@ -139,6 +148,36 @@ canvas_connected() {
     [ "$server_status" = "connected" ]
 }
 
+should_update_context_url() {
+    # Check if cli-session file exists
+    if [ ! -f "$CANVAS_SESSION" ]; then
+        return 1
+    fi
+    
+    # Get current time and file modification time
+    local current_time file_mtime time_diff
+    current_time=$(date +%s)
+    
+    # Get file modification time (platform independent)
+    if command -v stat >/dev/null 2>&1; then
+        # Try GNU stat first, then BSD stat
+        file_mtime=$(stat -c %Y "$CANVAS_SESSION" 2>/dev/null || stat -f %m "$CANVAS_SESSION" 2>/dev/null)
+    else
+        # Fallback if stat is not available
+        return 0  # Always update if we can't check file time
+    fi
+    
+    if [ -z "$file_mtime" ]; then
+        return 0  # Always update if we can't get file time
+    fi
+    
+    # Calculate time difference
+    time_diff=$((current_time - file_mtime))
+    
+    # Only update if file was modified more than CANVAS_CONTEXT_UPDATE_TIMEOUT seconds ago
+    [ "$time_diff" -ge "$CANVAS_CONTEXT_UPDATE_TIMEOUT" ]
+}
+
 mark_connection_unbound() {
     # Atomically update the session file to mark connection as unbound
     local temp_file="${CANVAS_SESSION}.tmp.$$"
@@ -162,13 +201,24 @@ get_context_url() {
     local session_data token api_url context_id
 
     session_data=$(get_session_data) || return 1
-    token=$(get_token) || return 1
-    api_url=$(get_api_url) || return 1
     context_id=$(echo "$session_data" | jq -r '.boundContextId // empty')
 
     if [ -z "$context_id" ]; then
         return 1
     fi
+
+    # Check if we should update based on file modification time
+    if ! should_update_context_url; then
+        # Return cached URL if available and within timeout
+        if [ -n "$_CACHED_CONTEXT_URL" ]; then
+            echo "$_CACHED_CONTEXT_URL"
+            return 0
+        fi
+    fi
+
+    # Need to update - get token and API URL
+    token=$(get_token) || return 1
+    api_url=$(get_api_url) || return 1
 
     # Make API call with aggressive timeout settings for maximum speed
     local response curl_exit_code
@@ -190,29 +240,38 @@ get_context_url() {
         if [ "$status" = "success" ]; then
             url=$(echo "$response" | jq -r '.payload.url // empty')
             if [ -n "$url" ]; then
+                # Cache the successful result
+                _CACHED_CONTEXT_URL="$url"
+                _LAST_CONTEXT_UPDATE=$(date +%s)
                 echo "$url"
                 return 0
             fi
         fi
     fi
 
-    # If curl failed or response was invalid, mark as unbound
+    # If curl failed or response was invalid, clear cache and mark as unbound
+    _CACHED_CONTEXT_URL=""
+    _LAST_CONTEXT_UPDATE=""
     mark_connection_unbound
     return 1
 }
 
 canvas_update_prompt() {
-    # Clear cache on each prompt update to ensure fresh data
+    # Clear session/remotes cache on each prompt update to ensure fresh data
+    # but preserve context URL cache which has its own timeout logic
     _SESSION_DATA=""
     _REMOTES_DATA=""
     
     # Fast check: if not connected, don't try API calls
     if ! canvas_connected; then
+        # Clear context URL cache when disconnected
+        _CACHED_CONTEXT_URL=""
+        _LAST_CONTEXT_UPDATE=""
         export PS1="[$CANVAS_PROMPT_RED●$CANVAS_PROMPT_RESET] $ORIGINAL_PROMPT"
         return
     fi
 
-    # Try to get current context URL from API (with fast timeout and failure handling)
+    # Try to get current context URL (with caching and timeout logic)
     local context_url context_id session_data
     
     # Get session data once and extract context_id
@@ -222,7 +281,7 @@ canvas_update_prompt() {
     }
     context_id=$(echo "$session_data" | jq -r '.boundContextId // empty')
     
-    # Try to get context URL - this will mark as unbound on failure
+    # Try to get context URL - this will use cache if within timeout
     context_url=$(get_context_url)
 
     if [ $? -eq 0 ] && [ -n "$context_url" ]; then


### PR DESCRIPTION
Add a configurable timeout and caching to `scripts/update-prompt.sh` to reduce server requests for context URL updates.

The context URL is a prompt feature that does not require real-time updates. This change introduces a configurable timeout (default 30s) and caching mechanism, preventing the script from making a server request for the context URL on every prompt command unless the `cli-session.json` file has been modified more recently than the timeout. This significantly reduces API calls and improves prompt responsiveness.

---
<a href="https://cursor.com/background-agent?bcId=bc-87e6c26d-72e3-456e-906f-2dc93d0e3ffc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87e6c26d-72e3-456e-906f-2dc93d0e3ffc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

